### PR TITLE
fixing build error with multiple definitions of stack  …

### DIFF
--- a/lib/wsprd/jelinek.c
+++ b/lib/wsprd/jelinek.c
@@ -24,6 +24,8 @@
 #define	POLY1	0xf2d05351
 #define	POLY2	0xe4613c47
 
+struct snode *stack;
+
 //Decoder - returns 0 on success, -1 on timeout
 int jelinek(
             unsigned int *metric,	/* Final path metric (returned value) */

--- a/lib/wsprd/jelinek.h
+++ b/lib/wsprd/jelinek.h
@@ -10,7 +10,7 @@ struct snode {
     unsigned int jpointer;
 };
 
-struct snode *stack;
+extern struct snode *stack;
 
 int jelinek(unsigned int *metric,
             unsigned int *cycles,


### PR DESCRIPTION
…on newer Linux systems, i.e. ubuntu 20.10

In reference to this ticket:
https://github.com/jtdx-project/jtdx/issues/7

