### PR TITLE
Removed unnecessary global declaration of stack

### DIFF
--- a/lib/wsprd/jelinek.h
+++ b/lib/wsprd/jelinek.h
@@ -10,8 +10,6 @@ struct snode {
     unsigned int jpointer;
 };
 
-struct snode *stack;
-
 int jelinek(unsigned int *metric,
             unsigned int *cycles,
             unsigned char *data,

--- a/lib/wsprd/wsprd.c
+++ b/lib/wsprd/wsprd.c
@@ -723,6 +723,7 @@ int main(int argc, char *argv[])
     int writec2=0,maxdrift;
     int shift1, lagmin, lagmax, lagstep, ifmin, ifmax, worth_a_try, not_decoded;
     unsigned int nbits=81, stacksize=200000;
+    struct snode *stack=NULL;
     unsigned int npoints, metric, cycles, maxnp;
     float df=375.0/256.0/2;
     float freq0[200],snr0[200],drift0[200],sync0[200];


### PR DESCRIPTION
By removing the global declaration of stack and
defining it locally where it is used, this code
now builds with gcc v10.  It should still build
with older gcc versions.  This is the correct
fix to issue #7. 