### PR TITLE
Fix spelling errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,10 @@ cmake_minimum_required (VERSION 3.7.2 FATAL_ERROR)
 
 if (APPLE)
   #
-  # The following variables define the portability and compatability attributes of the Mac macOS build
-  # they are choosen with care and should not be changed without good cause.
+  # The following variables define the portability and compatibility attributes of the Mac macOS build
+  # they are chosen with care and should not be changed without good cause.
   #
-  # Among other things these options are chosen to match the portability and compatability options of the
+  # Among other things these options are chosen to match the portability and compatibility options of the
   # Qt framework dylibs which can be checked as follows:
   #
   # otool -l <binary> | grep -A3 LC_VERSION_MIN_MACOSX
@@ -102,7 +102,7 @@ endif (BUILD_SHARED_LIBS)
 option (UPDATE_TRANSLATIONS "Update source translation translations/*.ts
 files (WARNING: make clean will delete the source .ts files! Danger!)")
 option (WSJT_SHARED_RUNTIME "Debugging option that allows running from a shared Cloud directory.")
-option (WSJT_QDEBUG_TO_FILE "Redirect Qt debuging messages to a trace file.")
+option (WSJT_QDEBUG_TO_FILE "Redirect Qt debugging messages to a trace file.")
 option (WSJT_TRACE_CAT "Debugging option that turns on CAT diagnostics.")
 option (WSJT_TRACE_CAT_POLLS "Debugging option that turns on CAT diagnostics during polling.")
 option (WSJT_HAMLIB_TRACE "Debugging option that turns on minimal Hamlib internal diagnostics.")
@@ -695,7 +695,7 @@ endif (WIN32)
 
 
 #
-# decide on platform specifc packing and fixing up
+# decide on platform specific packing and fixing up
 #
 if (APPLE)
   set (WSJTX_BUNDLE_VERSION ${wsjtx_VERSION})
@@ -884,7 +884,7 @@ set (CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 
 # set (CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
-# add the automaticaly determined parts of the RPATH which point to
+# add the automatically determined parts of the RPATH which point to
 # directories outside of the build tree to the install RPATH
 set (CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
@@ -922,7 +922,7 @@ set (QT_MKSPECS_DIR ${QT_DATA_DIR}/mkspecs)
 set (CMAKE_AUTOMOC ON)
 
 # don't use Qt "keywords" signal, slot, emit in generated files to
-# avoid compatability issue with other libraries
+# avoid compatibility issue with other libraries
 # ADD_DEFINITIONS (-DQT_NO_KEYWORDS)
 # ADD_DEFINITIONS (-DUNICODE)	#as per qmake
 

--- a/manpages/man1/jtdx.1.txt
+++ b/manpages/man1/jtdx.1.txt
@@ -77,7 +77,7 @@ applications settings dialog.
 
 ~/.local/share/JTDX[ - RIGNAME]/save/samples/::
 
-Sample .WAV files suppied with the application are found in this
+Sample .WAV files supplied with the application are found in this
 directory, they may be played back in the application and are referred
 to in the user guide tutorial sections.
 

--- a/package_description.txt
+++ b/package_description.txt
@@ -5,7 +5,7 @@ JTDX  Version  2.2 offers six different  protocols or modes: FT4, FT8,
 JT9, JT65, T10 and WSPR.
 .
 FT8 is the most popular mode of communication, JTDX  provides  matched 
-filter and own statistics based FT8 decoders with possibilty to decode 
+filter and own statistics based FT8 decoders with possibility to decode 
 some signals as low as -30 dB SNR in  a  2500 Hz  bandwidth.  JTDX FT8
 decoders do use  information  collected  from  previous  intervals  to
 decode signals in last interval.


### PR DESCRIPTION
This PR is the result of automatic edits made with the tool `codespell`.
It fixes one small spelling error in [manpages/man1/jtdx.1.txt](https://github.com/jtdx-project/jtdx/compare/master...dforsi:jtdx:fix/typos?expand=1#diff-e6af98dd24d7e63476e2b3f488c28b27fa600bedc9dc4b004faf13329df2a89d) and changes other two files, but It breaks the formatting in [package_description.txt](https://github.com/jtdx-project/jtdx/compare/master...dforsi:jtdx:fix/typos?expand=1#diff-c4c7bf1166ec3a79f4bc0ce2daed3c73db5be9eb495aa9045846c5147c2a81d3) I'm not sure ho to handle this, all lines should be reformatted?

The `codespell` shows more words that are possible errors, but it needs manual work to exclude some directories and some false positives; a starting point is:
`codespell --summary --skip=*.csv,*.dat,translations --ignore-words-list=ba,fo,inout,nd,rcall`

I can modify this PR or create a new PR but I'm not sure what directories should be skipped because contain files form upstream projects.