### PR TITLE
is_callsign(): Check size of callsign before indexing into it

### DIFF
--- a/Radio.cpp
+++ b/Radio.cpp
@@ -85,7 +85,7 @@ namespace Radio
 
   bool is_callsign (QString const& callsign)
   {
-    if ((!callsign.at(1).isDigit() && callsign.size () == 2) || callsign == "F" || callsign == "G" || callsign == "I" || callsign == "K" || callsign == "W") {
+    if ((callsign.size() > 1 && !callsign.at(1).isDigit() && callsign.size() == 2) || callsign == "F" || callsign == "G" || callsign == "I" || callsign == "K" || callsign == "W") {
         auto call = callsign + "0";
         return call.contains (valid_callsign_regexp);
     }


### PR DESCRIPTION
This was causing some crashes for me when I would see this parsing my logs on startup.

This would see a callsign like ANAAA/2 (where "A" is a letter, and "N" a number), splitting the callsign and checking if each part was a callsign with `is_callsign()`.
So when it'd be called like `is_callsign("2")`, it'd crash with calling `callsign.at(1)`